### PR TITLE
Some organization for table of contents

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -13,12 +13,17 @@ author = 'AtlanticWave-SDX Contributors'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = [
+    'sphinx.ext.todo'
+]
 
 templates_path = ['_templates']
 exclude_patterns = []
 
 language = 'en'
+
+# Display todos by setting to True
+todo_include_todos = True
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/source/index.rst
+++ b/source/index.rst
@@ -24,18 +24,20 @@ AtlanticWave-SDX project documentation
    sdx_lc_oxp.rst
    sdx_system_integration_test_procedure.rst
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Releases
-
-   sdx_release_notes_2.0.0.rst
-
 
 .. toctree::
    :maxdepth: 1
    :caption: Deploying and Running AtlanticWave-SDX
 
    sdx_deployment.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Releases
+
+   sdx_release_notes_2.0.0.rst
+
 
 
 Indices and tables

--- a/source/index.rst
+++ b/source/index.rst
@@ -24,6 +24,12 @@ AtlanticWave-SDX project documentation
    sdx_software_system_design.rst
    sdx_system_integration_test_procedure.rst
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Deploying and Running AtlanticWave-SDX
+
+   sdx_deployment.rst
+
 
 Indices and tables
 ==================

--- a/source/index.rst
+++ b/source/index.rst
@@ -18,9 +18,9 @@ AtlanticWave-SDX project documentation
    :caption: Developing the project
 
    sdx_developer_guidance.rst
-   sdx_software_system_design.rst   
+   sdx_software_system_design.rst
    sdx_data_model_development_procedure.rst
-   sdx_service_data_model_and_test_cases.rst   
+   sdx_service_data_model_and_test_cases.rst
    sdx_lc_oxp.rst
    sdx_system_integration_test_procedure.rst
 
@@ -37,12 +37,3 @@ AtlanticWave-SDX project documentation
    :caption: Releases
 
    sdx_release_notes_2.0.0.rst
-
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/source/index.rst
+++ b/source/index.rst
@@ -15,7 +15,7 @@ AtlanticWave-SDX project documentation
 
 .. toctree::
    :maxdepth: 1
-   :caption: Developing the project
+   :caption: Developing AtlanticWave-SDX
 
    sdx_developer_guidance.rst
    sdx_software_system_design.rst
@@ -27,7 +27,7 @@ AtlanticWave-SDX project documentation
 
 .. toctree::
    :maxdepth: 1
-   :caption: Deploying and Running AtlanticWave-SDX
+   :caption: Deploying AtlanticWave-SDX
 
    sdx_deployment.rst
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,7 +8,14 @@ AtlanticWave-SDX project documentation
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
+   :caption: Introduction
+
+   sdx_introduction.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Developing the project
 
    sdx_data_model_development_procedure.rst
    sdx_developer_guidance.rst

--- a/source/index.rst
+++ b/source/index.rst
@@ -26,6 +26,13 @@ AtlanticWave-SDX project documentation
 
 .. toctree::
    :maxdepth: 1
+   :caption: Releases
+
+   sdx_release_notes_2.0.0.rst
+
+
+.. toctree::
+   :maxdepth: 1
    :caption: Deploying and Running AtlanticWave-SDX
 
    sdx_deployment.rst

--- a/source/index.rst
+++ b/source/index.rst
@@ -17,11 +17,11 @@ AtlanticWave-SDX project documentation
    :maxdepth: 1
    :caption: Developing the project
 
-   sdx_data_model_development_procedure.rst
    sdx_developer_guidance.rst
+   sdx_software_system_design.rst   
+   sdx_data_model_development_procedure.rst
+   sdx_service_data_model_and_test_cases.rst   
    sdx_lc_oxp.rst
-   sdx_service_data_model_and_test_cases.rst
-   sdx_software_system_design.rst
    sdx_system_integration_test_procedure.rst
 
 .. toctree::

--- a/source/sdx_deployment.rst
+++ b/source/sdx_deployment.rst
@@ -1,0 +1,4 @@
+Deploying AtlanticWave-SDX
+==========================
+
+.. todo:: Write this.

--- a/source/sdx_introduction.rst
+++ b/source/sdx_introduction.rst
@@ -1,0 +1,4 @@
+About AtlanticWave-SDX
+======================
+
+.. todo:: Write this.

--- a/source/sdx_release_notes_2.0.0.rst
+++ b/source/sdx_release_notes_2.0.0.rst
@@ -1,0 +1,4 @@
+AtlanticWave-SDX 2.0 Release Notes 
+==================================
+
+.. todo:: Write this.


### PR DESCRIPTION
Resolves #5. Changes:

- Re-organzies the main table of contents somewhat.
- Adds some empty place-holder documents (intro, deployment, release notes) which we can expand later.
- Enables a "todo" Sphinx extension, so that todo items can be marked up like so: `.. todo:: write me`.